### PR TITLE
Add support to ignore extra tokens on a line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps.zig
 /test.in
 /test.out
 /test.expect
+/dist

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+dist: inttest
+	mkdir dist
+	cp zig-out/bin/skip dist/
+
+inttest: zig-out/bin/skip
+	./test.sh
+
+zig-out/bin/skip: unittest
+	zig build
+
+unittest: zigmod src/main.zig
+	zig build test
+
+zigmod: zig.mod
+	zigmod ci

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ line 4
 
 ### Skip until a number of matching lines
 
+The whole line must match.
+
 This example reads the named file.
 
 File: `input.txt`
@@ -67,7 +69,9 @@ gamma
 alpha
 ```
 
-### Skip lines until a number of tokens as seen
+### Skip lines until a number of tokens are seen
+
+Looks for a string within a line, counting each occurance.
 
 This example reads the file from stdin.
 
@@ -99,3 +103,44 @@ commodo consequat.
 
 It matches the first `dolor` on line 1,
  and the second on line 4 as part of the word `dolore`.
+
+### Skip lines until a lines with tokens are seen
+
+Looks for a string within a line, only counting each matching line once.
+
+This example reads the file from stdin.
+
+File: `input.txt`
+
+```text
+Lorem ipsum dolor sit amet, 
+consectetur adipiscing elit, 
+sed do eiusmod tempor incididunt 
+ut labore et dolore magna aliqua. 
+Ut enim ad minim veniam, 
+quis nostrud exercitation ullamco 
+laboris nisi ut aliquip ex ea 
+commodo consequat. 
+```
+
+```bash
+cat input.txt | skip 4 --token m --ignore-extras
+```
+
+Will output:
+
+```text
+quis nostrud exercitation ullamco 
+laboris nisi ut aliquip ex ea 
+commodo consequat. 
+```
+
+Without `--ignore-extras`, it would have found the fourth `m` on line 3, and displayed:
+
+```text
+ut labore et dolore magna aliqua. 
+Ut enim ad minim veniam, 
+quis nostrud exercitation ullamco 
+laboris nisi ut aliquip ex ea 
+commodo consequat. 
+```

--- a/src/main.zig
+++ b/src/main.zig
@@ -144,26 +144,23 @@ fn dumpInput(config: Config, in: fs.File, out: fs.File, allocator: mem.Allocator
     var c: usize = 0;
     while (c < config.lines) {
         const line = it.next();
-        if (config.line) |match| {
-            if (line) |memory| {
+        if (line) |memory| {
+            if (config.line) |match| {
                 if (mem.eql(u8, match, memory)) {
                     c += 1;
                 }
-            }
-        } else {
-            if (config.token) |token| {
-                if (line) |memory| {
-                    if (config.ignoreExtras) {
+            } else {
+                if (config.token) |token| {
+                    const occurances = mem.count(u8, memory, token);
+                    if (config.ignoreExtras and occurances > 0) {
                         c += 1;
                     } else {
-                        c += mem.count(u8, memory, token);
+                        c += occurances;
                     }
+                } else {
+                    c += 1;
                 }
-            } else {
-                c += 1;
             }
-        }
-        if (line) |memory| {
             allocator.free(memory);
         } else return;
     }
@@ -182,6 +179,7 @@ test "dumpInput skip 1 line" {
     const config = Config{
         .lines = 1,
         .file = file,
+        .ignoreExtras = false,
     };
 
     try dumpInput(config, file, output, testing.allocator);
@@ -212,6 +210,7 @@ test "dumpInput skip 2 line 'alpha'" {
         .lines = 2,
         .file = file,
         .line = "alpha",
+        .ignoreExtras = false,
     };
 
     try dumpInput(config, file, output, testing.allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,7 +66,7 @@ fn parseArgs(allocator: mem.Allocator) !Config {
     var diag = clap.Diagnostic{};
     var args = clap.parse(clap.Help, &params, .{ .diagnostic = &diag }) catch |err| {
         diag.report(io.getStdErr().writer(), err) catch {};
-        return err;
+        return error.EarlyExit;
     };
     defer args.deinit();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -153,7 +153,11 @@ fn dumpInput(config: Config, in: fs.File, out: fs.File, allocator: mem.Allocator
         } else {
             if (config.token) |token| {
                 if (line) |memory| {
-                    c += mem.count(u8, memory, token);
+                    if (config.ignoreExtras) {
+                        c += 1;
+                    } else {
+                        c += mem.count(u8, memory, token);
+                    }
                 }
             } else {
                 c += 1;

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,12 +11,6 @@ const clap = @import("clap");
 
 const version = "0.1.0";
 
-// step 1: [x] read in a file from stdin and write out to stdout
-// step 2: [x] read in a named file in parameters and write out to stdout
-// step 3: [x] skip a number of lines
-// step 4: [ ] skip a number of matching lines
-// step 5: [ ] skip a number of tokens
-
 const maxLineLength = 4096;
 
 pub fn main() anyerror!void {

--- a/test.sh
+++ b/test.sh
@@ -58,6 +58,13 @@ EOF
 ./skip 2 test.in --token dolor > test.out
 diff --brief test.expect test.out
 
+echo "> handle unknown parameter with simple error message"
+cat<<EOF > test.expect
+Invalid argument '--foo'
+EOF
+./skip --foo  > test.out 2>&1 || ## error is expected
+diff --brief test.expect test.out
+
 rm test.in test.out test.expect
 
 echo done

--- a/test.sh
+++ b/test.sh
@@ -88,7 +88,7 @@ diff --brief test.expect.err test.err
 rm test.expect test.out
 rm test.expect.err test.err
 
-echo "> skip lines until 3 tokens seen - ignored extra tokens on same line"
+echo "> skip lines until 4 tokens seen - ignored extra tokens on same line"
 cat<<EOF > test.in
 Lorem ipsum dolor sit amet, 
 consectetur adipiscing elit, 
@@ -104,7 +104,7 @@ quis nostrud exercitation ullamco
 laboris nisi ut aliquip ex ea 
 commodo consequat. 
 EOF
-./skip 3 test.in --token m --ignore-extras > test.out
+./skip 4 test.in --token m --ignore-extras > test.out
 diff --brief test.expect test.out
 rm test.in test.expect test.out
 

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,7 @@ EOF
 echo "line 2" > test.expect
 echo "$INPUT" | ./skip 1 > test.out
 diff --brief test.expect test.out
+rm test.expect test.out
 
 echo "> skip a line when reading from a file"
 cat<<EOF > test.in
@@ -20,6 +21,7 @@ EOF
 echo "line 2" > test.expect
 ./skip 1 test.in > test.out
 diff --brief test.expect test.out
+rm test.expect test.out
 
 echo "> skip until 2 matching lines seen"
 cat<<EOF > test.in
@@ -37,6 +39,7 @@ alpha
 EOF
 ./skip 2 test.in --line alpha > test.out
 diff --brief test.expect test.out
+rm test.in test.expect test.out
 
 echo "> skip lines until 2 tokens seen"
 cat<<EOF > test.in
@@ -55,15 +58,22 @@ quis nostrud exercitation ullamco
 laboris nisi ut aliquip ex ea 
 commodo consequat. 
 EOF
-./skip 2 test.in --token dolor > test.out
+./skip 2 test.in --token dolor > test.out 2
 diff --brief test.expect test.out
+rm test.in test.expect test.out
 
 echo "> handle unknown parameter with simple error message"
-cat<<EOF > test.expect
+cat<<EOF > test.expect.err
 Invalid argument '--foo'
 EOF
-./skip --foo  > test.out 2>&1 || ## error is expected
+cat<<EOF > test.expect
+EOF
+touch test.out test.err
+./skip --foo > test.out 2> test.err
 diff --brief test.expect test.out
+diff --brief test.expect.err test.err
+rm test.expect test.out
+rm test.expect.err test.err
 
 echo "> skip lines until 3 tokens seen - ignored extra tokens on same line"
 cat<<EOF > test.in
@@ -83,7 +93,6 @@ commodo consequat.
 EOF
 ./skip 3 test.in --token m --ignore-extras > test.out
 diff --brief test.expect test.out
-
-rm test.in test.out test.expect
+rm test.in test.expect test.out
 
 echo done

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 SKIP="./zig-out/bin/skip"
-DIFF="diff -u"
+DIFF="diff -u --color"
 
 if test ! -x $SKIP ; then
     echo "File missing: $SKIP - try 'zig build'"

--- a/test.sh
+++ b/test.sh
@@ -75,6 +75,19 @@ diff --brief test.expect.err test.err
 rm test.expect test.out
 rm test.expect.err test.err
 
+echo "> handle ignore-extra when token is missing"
+cat<<EOF > test.expect.err
+Error: --ignore-extras requires --token
+EOF
+cat<<EOF > test.expect
+EOF
+touch test.out test.err
+./skip --ignore-extras > test.out 2> test.err
+diff --brief test.expect test.out
+diff --brief test.expect.err test.err
+rm test.expect test.out
+rm test.expect.err test.err
+
 echo "> skip lines until 3 tokens seen - ignored extra tokens on same line"
 cat<<EOF > test.in
 Lorem ipsum dolor sit amet, 

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+SKIP="./zig-out/bin/skip"
+DIFF="diff -u"
+
+if test ! -x $SKIP ; then
+    echo "File missing: $SKIP - try 'zig build'"
+    exit 1
+fi
+
 echo "> skip a line when reading from stdin"
 INPUT=$(cat<<EOF
 line 1
@@ -9,8 +17,8 @@ line 2
 EOF
 )
 echo "line 2" > test.expect
-echo "$INPUT" | ./skip 1 > test.out
-diff --brief test.expect test.out
+echo "$INPUT" | $SKIP 1 > test.out
+$DIFF test.expect test.out
 rm test.expect test.out
 
 echo "> skip a line when reading from a file"
@@ -19,8 +27,8 @@ line 1
 line 2
 EOF
 echo "line 2" > test.expect
-./skip 1 test.in > test.out
-diff --brief test.expect test.out
+$SKIP 1 test.in > test.out
+$DIFF test.expect test.out
 rm test.expect test.out
 
 echo "> skip until 2 matching lines seen"
@@ -37,8 +45,8 @@ alpha
 gamma
 alpha
 EOF
-./skip 2 test.in --line alpha > test.out
-diff --brief test.expect test.out
+$SKIP 2 test.in --line alpha > test.out
+$DIFF test.expect test.out
 rm test.in test.expect test.out
 
 echo "> skip lines until 2 tokens seen"
@@ -58,8 +66,8 @@ quis nostrud exercitation ullamco
 laboris nisi ut aliquip ex ea 
 commodo consequat. 
 EOF
-./skip 2 test.in --token dolor > test.out 2
-diff --brief test.expect test.out
+$SKIP 2 test.in --token dolor > test.out 2
+$DIFF test.expect test.out
 rm test.in test.expect test.out
 
 echo "> handle unknown parameter with simple error message"
@@ -69,9 +77,9 @@ EOF
 cat<<EOF > test.expect
 EOF
 touch test.out test.err
-./skip --foo > test.out 2> test.err
-diff --brief test.expect test.out
-diff --brief test.expect.err test.err
+$SKIP --foo > test.out 2> test.err
+$DIFF test.expect test.out
+$DIFF test.expect.err test.err
 rm test.expect test.out
 rm test.expect.err test.err
 
@@ -82,9 +90,9 @@ EOF
 cat<<EOF > test.expect
 EOF
 touch test.out test.err
-./skip --ignore-extras > test.out 2> test.err
-diff --brief test.expect test.out
-diff --brief test.expect.err test.err
+$SKIP --ignore-extras > test.out 2> test.err
+$DIFF test.expect test.out
+$DIFF test.expect.err test.err
 rm test.expect test.out
 rm test.expect.err test.err
 
@@ -104,8 +112,8 @@ quis nostrud exercitation ullamco
 laboris nisi ut aliquip ex ea 
 commodo consequat. 
 EOF
-./skip 4 test.in --token m --ignore-extras > test.out
-diff --brief test.expect test.out
+$SKIP 4 test.in --token m --ignore-extras > test.out
+$DIFF test.expect test.out
 rm test.in test.expect test.out
 
 echo done

--- a/test.sh
+++ b/test.sh
@@ -65,6 +65,25 @@ EOF
 ./skip --foo  > test.out 2>&1 || ## error is expected
 diff --brief test.expect test.out
 
+echo "> skip lines until 3 tokens seen - ignored extra tokens on same line"
+cat<<EOF > test.in
+Lorem ipsum dolor sit amet, 
+consectetur adipiscing elit, 
+sed do eiusmod tempor incididunt 
+ut labore et dolore magna aliqua. 
+Ut enim ad minim veniam, 
+quis nostrud exercitation ullamco 
+laboris nisi ut aliquip ex ea 
+commodo consequat. 
+EOF
+cat<<EOF > test.expect
+quis nostrud exercitation ullamco 
+laboris nisi ut aliquip ex ea 
+commodo consequat. 
+EOF
+./skip 3 test.in --token m --ignore-extras > test.out
+diff --brief test.expect test.out
+
 rm test.in test.out test.expect
 
 echo done


### PR DESCRIPTION
- Add test to handle unknown arguments gracefully
- remove out-of-date dev notes
- Add test for option --ignore-extras
- Don't show error trace when bar args
- Clean up after each test and test stderr
- Accept --ignore-extras argument
- ignore extra tokens on a line
